### PR TITLE
Refactor(ProviderIntegrations): Yalidine and Procolis

### DIFF
--- a/src/ProviderIntegrations/ProcolisProviderIntegration.php
+++ b/src/ProviderIntegrations/ProcolisProviderIntegration.php
@@ -13,12 +13,16 @@ use CourierDZ\Exceptions\TrackingIdNotFoundException;
 use CourierDZ\Support\ShippingProviderValidation;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Psr7\Request;
 use http\Exception\InvalidArgumentException;
 
 abstract class ProcolisProviderIntegration implements ShippingProviderContract
 {
     use ShippingProviderValidation;
+
+    /**
+     * Init Guzzle Client
+     */
+    protected Client $client;
 
     /**
      * Provider credentials
@@ -66,6 +70,8 @@ abstract class ProcolisProviderIntegration implements ShippingProviderContract
 
         // Store the credentials
         $this->credentials = $credentials;
+        // Set the client
+        $this->client = $this->initClient();
     }
 
     // test credentials method
@@ -81,19 +87,8 @@ abstract class ProcolisProviderIntegration implements ShippingProviderContract
     public function testCredentials(): bool
     {
         try {
-            // Initialize Guzzle client
-            $client = new Client;
-
-            // Define the headers
-            $headers = [
-                'token' => $this->credentials['token'],
-                'key' => $this->credentials['key'],
-            ];
-
             // Make the GET request
-            $response = $client->request('GET', 'https://procolis.com/api_v1/token', [
-                'headers' => $headers,
-            ]);
+            $response = $this->client->get('token');
 
             // Get the response body
             $body = $response->getBody()->getContents();
@@ -123,20 +118,8 @@ abstract class ProcolisProviderIntegration implements ShippingProviderContract
     public function getRates(?int $from_wilaya_id = null, ?int $to_wilaya_id = null): array
     {
         try {
-            // Initialize Guzzle client
-            $client = new Client;
-
-            // Define the headers
-            $headers = [
-                'token' => $this->credentials['token'],
-                'key' => $this->credentials['key'],
-                'Content-Type' => 'application/json',
-            ];
-
             // Make the GET request
-            $response = $client->request('POST', 'https://procolis.com/api_v1/tarification', [
-                'headers' => $headers,
-            ]);
+            $response = $this->client->get('tarification');
 
             // Get the response body
             $body = $response->getBody()->getContents();
@@ -185,32 +168,18 @@ abstract class ProcolisProviderIntegration implements ShippingProviderContract
         $this->validateCreate($orderData);
 
         // Prepare the request body
-        $data = [
+        $requestBody = json_encode([
             'Colis' => [
                 $orderData,
             ],
-        ];
-
-        $requestBody = json_encode($data, JSON_UNESCAPED_UNICODE);
+        ], JSON_UNESCAPED_UNICODE);
 
         if ($requestBody === false) {
             throw new CreateOrderException('Create Order failed ( JSON Encoding Error ) : '.json_last_error_msg());
         }
 
         try {
-            // Initialize Guzzle client
-            $client = new Client;
-
-            // Define the headers
-            $headers = [
-                'token' => $this->credentials['token'],
-                'key' => $this->credentials['key'],
-                'Content-Type' => 'application/json',
-            ];
-
-            $request = new Request('POST', 'https://procolis.com/api_v1/add_colis', $headers, $requestBody);
-
-            $response = $client->send($request);
+            $response = $this->client->post('add_colis', ['body' => $requestBody]);
 
             // Get the response body
             $body = $response->getBody()->getContents();
@@ -243,32 +212,18 @@ abstract class ProcolisProviderIntegration implements ShippingProviderContract
      */
     public function getOrder(string $trackingId): array
     {
-        $data = [
+        $requestBody = json_encode([
             'Colis' => [
                 ['Tracking' => $trackingId],
             ],
-        ];
-
-        $requestBody = json_encode($data, JSON_UNESCAPED_UNICODE);
+        ], JSON_UNESCAPED_UNICODE);
 
         if ($requestBody === false) {
             throw new InvalidArgumentException('$trackingId must be a non-empty string');
         }
 
         try {
-            // Initialize Guzzle client
-            $client = new Client;
-
-            // Define the headers
-            $headers = [
-                'token' => $this->credentials['token'],
-                'key' => $this->credentials['key'],
-                'Content-Type' => 'application/json',
-            ];
-
-            $request = new Request('POST', 'https://procolis.com/api_v1/lire', $headers, $requestBody);
-
-            $response = $client->send($request);
+            $response = $this->client->post('lire', ['body' => $requestBody]);
 
             // Get the response body
             $body = $response->getBody()->getContents();
@@ -308,4 +263,18 @@ abstract class ProcolisProviderIntegration implements ShippingProviderContract
      * {@inheritdoc}
      */
     abstract public static function metadata(): array;
+
+    private function initClient(): Client
+    {
+        // Initialize Guzzle client
+        return new Client([
+            'base_uri' => 'https://procolis.com/api_v1/',
+            'http_errors' => false,
+            'headers' => [
+                'X-API-ID' => $this->credentials['token'],
+                'X-API-TOKEN' => $this->credentials['key'],
+                'Content-Type' => 'application/json',
+            ],
+        ]);
+    }
 }

--- a/src/ProviderIntegrations/YalidineProviderIntegration.php
+++ b/src/ProviderIntegrations/YalidineProviderIntegration.php
@@ -12,11 +12,15 @@ use CourierDZ\Exceptions\TrackingIdNotFoundException;
 use CourierDZ\Support\ShippingProviderValidation;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Psr7\Request;
 
 abstract class YalidineProviderIntegration implements ShippingProviderContract
 {
     use ShippingProviderValidation;
+
+    /**
+     * Init Guzzle Client
+     */
+    protected Client $client;
 
     /**
      * Provider credentials
@@ -73,6 +77,8 @@ abstract class YalidineProviderIntegration implements ShippingProviderContract
 
         // Set the credentials
         $this->credentials = $credentials;
+        // Set the client
+        $this->client = $this->initClient();
     }
 
     /**
@@ -98,20 +104,8 @@ abstract class YalidineProviderIntegration implements ShippingProviderContract
     public function testCredentials(): bool
     {
         try {
-            // Initialize Guzzle client
-            $client = new Client(['http_errors' => false]);
-
-            // Define the headers
-            $headers = [
-                'X-API-ID' => $this->credentials['id'],
-                'X-API-TOKEN' => $this->credentials['token'],
-            ];
-
             // Make the GET request
-            $response = $client->request('GET', static::apiDomain().'/v1/wilayas/', [
-                'headers' => $headers,
-            ]);
-
+            $response = $this->client->get('wilayas');
             // If the request is successful, the credentials are valid
             if ($response->getStatusCode() === 200) {
                 return true;
@@ -138,19 +132,8 @@ abstract class YalidineProviderIntegration implements ShippingProviderContract
     public function getRates(?int $from_wilaya_id = null, ?int $to_wilaya_id = null): array
     {
         try {
-            // Initialize Guzzle client
-            $client = new Client(['http_errors' => false]);
-
-            // Define the headers
-            $headers = [
-                'X-API-ID' => $this->credentials['id'],
-                'X-API-TOKEN' => $this->credentials['token'],
-            ];
-
             // Make the GET request
-            $response = $client->request('GET', static::apiDomain().'/v1/fees/?from_wilaya_id='.$from_wilaya_id.'&to_wilaya_id='.$to_wilaya_id, [
-                'headers' => $headers,
-            ]);
+            $response = $this->client->get('fees/?from_wilaya_id='.$from_wilaya_id.'&to_wilaya_id='.$to_wilaya_id);
 
             // Return the response body as an array
             return json_decode($response->getBody()->getContents(), true);
@@ -174,25 +157,15 @@ abstract class YalidineProviderIntegration implements ShippingProviderContract
         $this->validateCreate($orderData);
 
         try {
-            // Initialize Guzzle client
-            $client = new Client;
-
-            // Define the headers
-            $headers = [
-                'X-API-ID' => $this->credentials['id'],
-                'X-API-TOKEN' => $this->credentials['token'],
-                'Content-Type' => 'application/json',
-            ];
-
             $requestBody = json_encode([$orderData], JSON_UNESCAPED_UNICODE);
 
             if ($requestBody === false) {
                 throw new CreateOrderException('Create Order failed : JSON encoding error');
             }
 
-            $request = new Request('POST', static::apiDomain().'/v1/parcels/', $headers, $requestBody);
-
-            $response = $client->send($request);
+            $response = $this->client->post('parcels', [
+                'body' => $requestBody,
+            ]);
 
             // Get the response body
             $body = $response->getBody()->getContents();
@@ -239,19 +212,8 @@ abstract class YalidineProviderIntegration implements ShippingProviderContract
     public function getOrder(string $trackingId): array
     {
         try {
-            // Initialize Guzzle client
-            $client = new Client(['http_errors' => false]);
-
-            // Define the headers
-            $headers = [
-                'X-API-ID' => $this->credentials['id'],
-                'X-API-TOKEN' => $this->credentials['token'],
-            ];
-
             // Make the GET request
-            $response = $client->request('GET', 'https://api.yalidine.app/v1/parcels/'.$trackingId, [
-                'headers' => $headers,
-            ]);
+            $response = $this->client->get('parcels/'.$trackingId);
 
             $data = json_decode($response->getBody()->getContents(), true);
 
@@ -265,5 +227,19 @@ abstract class YalidineProviderIntegration implements ShippingProviderContract
             // Handle exceptions
             throw new HttpException($guzzleException->getMessage());
         }
+    }
+
+    private function initClient(): Client
+    {
+        // Initialize Guzzle client
+        return new Client([
+            'base_uri' => 'https://api.yalidine.app/v1/',
+            'http_errors' => false,
+            'headers' => [
+                'X-API-ID' => $this->credentials['id'],
+                'X-API-TOKEN' => $this->credentials['token'],
+                'Content-Type' => 'application/json',
+            ],
+        ]);
     }
 }


### PR DESCRIPTION
Instead of creating a **new Guzzle client** for each function call, which is resource-intensive.

For example: imagine within a business logic you needed **fees** with **parcels** or any other combination of data; here you need to build the Guzzle client **multiple times.** for each function call :

gerPercels(), getFees()

So it is convenient to create **one client on each object creation** and use it multiple times. each provider integration has its own client initialization using the appropriate headers.

I have another refactoring ideas on how to restructure the package and remove unnecessary classes in a cleaner way; reach out to me if you're interested.